### PR TITLE
README.md: change to new launch binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ open /Applications/Winbox-mac.app --args ip login password
 
 ## Note
 
-To properly import/export addresses you have to run `Winbox-mac.app/Contents/MacOS/startwine` from CLI or add `/bin/bash` to Security & Privacy → Privacy → Full Disk Access. To be able to see hidden files in file choosing dialog press <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>.</kbd>.
+To properly import/export addresses you have to run `Winbox-mac.app/Contents/MacOS/startwine` from CLI or add `/usr/bin/env` to Security & Privacy → Privacy → Full Disk Access. To be able to see hidden files in file choosing dialog press <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>.</kbd>.
 
 ## Reporting bugs
 


### PR DESCRIPTION
We’re now launching via `/usr/bin/env` and not `/bin/bash`